### PR TITLE
Replace deprecated IdentityServer4 with Duende IdentityServer

### DIFF
--- a/IdentityServer/Config.cs
+++ b/IdentityServer/Config.cs
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityServer4;
-using IdentityServer4.Models;
+using Duende.IdentityServer;
+using Duende.IdentityServer.Models;
 using System.Collections.Generic;
 
 namespace IdentityServer

--- a/IdentityServer/IdentityServer.csproj
+++ b/IdentityServer/IdentityServer.csproj
@@ -9,8 +9,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="IdentityServer4" Version="4.1.2" />
-    <PackageReference Include="IdentityServer4.EntityFramework" Version="4.1.2" />
+    <PackageReference Include="Duende.IdentityServer" Version="6.0.0" />
+    <PackageReference Include="Duende.IdentityServer.EntityFramework" Version="6.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="7.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.5" />

--- a/IdentityServer/ProfileService.cs
+++ b/IdentityServer/ProfileService.cs
@@ -1,5 +1,5 @@
-﻿using IdentityServer4.Models;
-using IdentityServer4.Services;
+﻿using Duende.IdentityServer.Models;
+using Duende.IdentityServer.Services;
 using Serilog;
 using System;
 using System.Collections.Generic;

--- a/IdentityServer/Program.cs
+++ b/IdentityServer/Program.cs
@@ -15,7 +15,7 @@ namespace IdentityServer
     {
         public static void Main(string[] args)
         {
-            Console.Title = "IdentityServer4";
+            Console.Title = "Duende IdentityServer";
 
             CreateWebHostBuilder(args).Build().Run();
         }
@@ -32,7 +32,7 @@ namespace IdentityServer
                             .MinimumLevel.Override("System", LogEventLevel.Warning)
                             .MinimumLevel.Override("Microsoft.AspNetCore.Authentication", LogEventLevel.Information)
                             .Enrich.FromLogContext()
-                            .WriteTo.File(@"identityserver4_log.txt")
+                            .WriteTo.File(@"identityserver_log.txt")
                             .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level}] {SourceContext}{NewLine}{Message:lj}{NewLine}{Exception}{NewLine}", theme: AnsiConsoleTheme.Literate);
                     });
         }

--- a/IdentityServer/Quickstart/Account/AccountController.cs
+++ b/IdentityServer/Quickstart/Account/AccountController.cs
@@ -4,13 +4,13 @@
 
 using IdentityModel;
 using IdentityServer;
-using IdentityServer4;
-using IdentityServer4.Events;
-using IdentityServer4.Extensions;
-using IdentityServer4.Models;
-using IdentityServer4.Services;
-using IdentityServer4.Stores;
-using IdentityServer4.Test;
+using Duende.IdentityServer;
+using Duende.IdentityServer.Events;
+using Duende.IdentityServer.Extensions;
+using Duende.IdentityServer.Models;
+using Duende.IdentityServer.Services;
+using Duende.IdentityServer.Stores;
+using Duende.IdentityServer.Test;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -248,7 +248,7 @@ namespace IdentityServerHost.Quickstart.UI
             var context = await _interaction.GetAuthorizationContextAsync(returnUrl);
             if (context?.IdP != null && await _schemeProvider.GetSchemeAsync(context.IdP) != null)
             {
-                var local = context.IdP == IdentityServer4.IdentityServerConstants.LocalIdentityProvider;
+                var local = context.IdP == Duende.IdentityServer.IdentityServerConstants.LocalIdentityProvider;
 
                 // this is meant to short circuit the UI and only trigger the one external IdP
                 var vm = new LoginViewModel
@@ -350,7 +350,7 @@ namespace IdentityServerHost.Quickstart.UI
             if (User?.Identity.IsAuthenticated == true)
             {
                 var idp = User.FindFirst(JwtClaimTypes.IdentityProvider)?.Value;
-                if (idp != null && idp != IdentityServer4.IdentityServerConstants.LocalIdentityProvider)
+                if (idp != null && idp != Duende.IdentityServer.IdentityServerConstants.LocalIdentityProvider)
                 {
                     var providerSupportsSignout = await HttpContext.GetSchemeSupportsSignOutAsync(idp);
                     if (providerSupportsSignout)

--- a/IdentityServer/Quickstart/Account/ExternalController.cs
+++ b/IdentityServer/Quickstart/Account/ExternalController.cs
@@ -1,9 +1,9 @@
 using IdentityModel;
-using IdentityServer4;
-using IdentityServer4.Events;
-using IdentityServer4.Services;
-using IdentityServer4.Stores;
-using IdentityServer4.Test;
+using Duende.IdentityServer;
+using Duende.IdentityServer.Events;
+using Duende.IdentityServer.Services;
+using Duende.IdentityServer.Stores;
+using Duende.IdentityServer.Test;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;

--- a/IdentityServer/Quickstart/Consent/ConsentController.cs
+++ b/IdentityServer/Quickstart/Consent/ConsentController.cs
@@ -2,16 +2,16 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityServer4.Events;
-using IdentityServer4.Models;
-using IdentityServer4.Services;
-using IdentityServer4.Extensions;
+using Duende.IdentityServer.Events;
+using Duende.IdentityServer.Models;
+using Duende.IdentityServer.Services;
+using Duende.IdentityServer.Extensions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using System.Linq;
 using System.Threading.Tasks;
-using IdentityServer4.Validation;
+using Duende.IdentityServer.Validation;
 using System.Collections.Generic;
 using System;
 
@@ -120,7 +120,7 @@ namespace IdentityServerHost.Quickstart.UI
                     var scopes = model.ScopesConsented;
                     if (ConsentOptions.EnableOfflineAccess == false)
                     {
-                        scopes = scopes.Where(x => x != IdentityServer4.IdentityServerConstants.StandardScopes.OfflineAccess);
+                        scopes = scopes.Where(x => x != Duende.IdentityServer.IdentityServerConstants.StandardScopes.OfflineAccess);
                     }
 
                     grantedConsent = new ConsentResponse
@@ -208,7 +208,7 @@ namespace IdentityServerHost.Quickstart.UI
             }
             if (ConsentOptions.EnableOfflineAccess && request.ValidatedResources.Resources.OfflineAccess)
             {
-                apiScopes.Add(GetOfflineAccessScope(vm.ScopesConsented.Contains(IdentityServer4.IdentityServerConstants.StandardScopes.OfflineAccess) || model == null));
+                apiScopes.Add(GetOfflineAccessScope(vm.ScopesConsented.Contains(Duende.IdentityServer.IdentityServerConstants.StandardScopes.OfflineAccess) || model == null));
             }
             vm.ApiScopes = apiScopes;
 
@@ -251,7 +251,7 @@ namespace IdentityServerHost.Quickstart.UI
         {
             return new ScopeViewModel
             {
-                Value = IdentityServer4.IdentityServerConstants.StandardScopes.OfflineAccess,
+                Value = Duende.IdentityServer.IdentityServerConstants.StandardScopes.OfflineAccess,
                 DisplayName = ConsentOptions.OfflineAccessDisplayName,
                 Description = ConsentOptions.OfflineAccessDescription,
                 Emphasize = true,

--- a/IdentityServer/Quickstart/Consent/ProcessConsentResult.cs
+++ b/IdentityServer/Quickstart/Consent/ProcessConsentResult.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityServer4.Models;
+using Duende.IdentityServer.Models;
 
 namespace IdentityServerHost.Quickstart.UI
 {

--- a/IdentityServer/Quickstart/Device/DeviceController.cs
+++ b/IdentityServer/Quickstart/Device/DeviceController.cs
@@ -6,12 +6,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using IdentityServer4.Configuration;
-using IdentityServer4.Events;
-using IdentityServer4.Extensions;
-using IdentityServer4.Models;
-using IdentityServer4.Services;
-using IdentityServer4.Validation;
+using Duende.IdentityServer.Configuration;
+using Duende.IdentityServer.Events;
+using Duende.IdentityServer.Extensions;
+using Duende.IdentityServer.Models;
+using Duende.IdentityServer.Services;
+using Duende.IdentityServer.Validation;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -102,7 +102,7 @@ namespace IdentityServerHost.Quickstart.UI
                     var scopes = model.ScopesConsented;
                     if (ConsentOptions.EnableOfflineAccess == false)
                     {
-                        scopes = scopes.Where(x => x != IdentityServer4.IdentityServerConstants.StandardScopes.OfflineAccess);
+                        scopes = scopes.Where(x => x != Duende.IdentityServer.IdentityServerConstants.StandardScopes.OfflineAccess);
                     }
 
                     grantedConsent = new ConsentResponse
@@ -184,7 +184,7 @@ namespace IdentityServerHost.Quickstart.UI
             }
             if (ConsentOptions.EnableOfflineAccess && request.ValidatedResources.Resources.OfflineAccess)
             {
-                apiScopes.Add(GetOfflineAccessScope(vm.ScopesConsented.Contains(IdentityServer4.IdentityServerConstants.StandardScopes.OfflineAccess) || model == null));
+                apiScopes.Add(GetOfflineAccessScope(vm.ScopesConsented.Contains(Duende.IdentityServer.IdentityServerConstants.StandardScopes.OfflineAccess) || model == null));
             }
             vm.ApiScopes = apiScopes;
 
@@ -221,7 +221,7 @@ namespace IdentityServerHost.Quickstart.UI
         {
             return new ScopeViewModel
             {
-                Value = IdentityServer4.IdentityServerConstants.StandardScopes.OfflineAccess,
+                Value = Duende.IdentityServer.IdentityServerConstants.StandardScopes.OfflineAccess,
                 DisplayName = ConsentOptions.OfflineAccessDisplayName,
                 Description = ConsentOptions.OfflineAccessDescription,
                 Emphasize = true,

--- a/IdentityServer/Quickstart/Extensions.cs
+++ b/IdentityServer/Quickstart/Extensions.cs
@@ -1,5 +1,5 @@
 using System;
-using IdentityServer4.Models;
+using Duende.IdentityServer.Models;
 using Microsoft.AspNetCore.Mvc;
 
 namespace IdentityServerHost.Quickstart.UI

--- a/IdentityServer/Quickstart/Grants/GrantsController.cs
+++ b/IdentityServer/Quickstart/Grants/GrantsController.cs
@@ -2,15 +2,15 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityServer4.Services;
-using IdentityServer4.Stores;
+using Duende.IdentityServer.Services;
+using Duende.IdentityServer.Stores;
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
-using IdentityServer4.Events;
-using IdentityServer4.Extensions;
+using Duende.IdentityServer.Events;
+using Duende.IdentityServer.Extensions;
 
 namespace IdentityServerHost.Quickstart.UI
 {

--- a/IdentityServer/Quickstart/Home/ErrorViewModel.cs
+++ b/IdentityServer/Quickstart/Home/ErrorViewModel.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityServer4.Models;
+using Duende.IdentityServer.Models;
 
 namespace IdentityServerHost.Quickstart.UI
 {

--- a/IdentityServer/Quickstart/Home/HomeController.cs
+++ b/IdentityServer/Quickstart/Home/HomeController.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityServer4.Services;
+using Duende.IdentityServer.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;

--- a/IdentityServer/Quickstart/TestUsers.cs
+++ b/IdentityServer/Quickstart/TestUsers.cs
@@ -3,11 +3,11 @@
 
 
 using IdentityModel;
-using IdentityServer4.Test;
+using Duende.IdentityServer.Test;
 using System.Collections.Generic;
 using System.Security.Claims;
 using System.Text.Json;
-using IdentityServer4;
+using Duende.IdentityServer;
 
 namespace IdentityServerHost.Quickstart.UI
 {

--- a/IdentityServer/ResourceOwnerPasswordValidator.cs
+++ b/IdentityServer/ResourceOwnerPasswordValidator.cs
@@ -1,6 +1,6 @@
 ﻿using IdentityModel;
-using IdentityServer4.Models;
-using IdentityServer4.Validation;
+using Duende.IdentityServer.Models;
+using Duende.IdentityServer.Validation;
 using Serilog;
 using System;
 using System.Collections.Generic;

--- a/IdentityServer/Startup.cs
+++ b/IdentityServer/Startup.cs
@@ -2,9 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityServer4;
-using IdentityServer4.Services;
-using IdentityServer4.Validation;
+using Duende.IdentityServer;
+using Duende.IdentityServer.Services;
+using Duende.IdentityServer.Validation;
 using IdentityServerHost.Quickstart.UI;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;

--- a/IdentityServer/Views/Home/Index.cshtml
+++ b/IdentityServer/Views/Home/Index.cshtml
@@ -1,13 +1,13 @@
 @using System.Diagnostics
 
 @{
-    var version = FileVersionInfo.GetVersionInfo(typeof(IdentityServer4.Hosting.IdentityServerMiddleware).Assembly.Location).ProductVersion.Split('+').First();
+    var version = FileVersionInfo.GetVersionInfo(typeof(Duende.IdentityServer.Hosting.IdentityServerMiddleware).Assembly.Location).ProductVersion.Split('+').First();
 }
 
 <div class="welcome-page">
     <h1>
         <img src="~/icon.jpg">
-        Welcome to IdentityServer4
+        Welcome to Duende IdentityServer
         <small class="text-muted">(version @version)</small>
     </h1>
 
@@ -25,8 +25,8 @@
         </li>
         <li>
             Here are links to the
-            <a href="https://github.com/identityserver/IdentityServer4">source code repository</a>,
-            and <a href="https://github.com/IdentityServer/IdentityServer4/tree/main/samples">ready to use samples</a>.
+            <a href="https://github.com/DuendeSoftware/IdentityServer">source code repository</a>,
+            and <a href="https://github.com/DuendeSoftware/IdentityServer/tree/main/samples">ready to use samples</a>.
         </li>
     </ul>
 </div>

--- a/IdentityServer/Views/Shared/_Layout.cshtml
+++ b/IdentityServer/Views/Shared/_Layout.cshtml
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no" />
 
-    <title>IdentityServer4</title>
+    <title>Duende IdentityServer</title>
     
     <link rel="icon" type="image/x-icon" href="~/favicon.ico" />
     <link rel="shortcut icon" type="image/x-icon" href="~/favicon.ico" />

--- a/IdentityServer/Views/Shared/_Nav.cshtml
+++ b/IdentityServer/Views/Shared/_Nav.cshtml
@@ -1,4 +1,4 @@
-@using IdentityServer4.Extensions
+@using Duende.IdentityServer.Extensions
 
 @{
     string name = null;
@@ -13,7 +13,7 @@
 
         <a href="~/" class="navbar-brand">
             <img src="~/icon.png" class="icon-banner">
-            IdentityServer4
+            Duende IdentityServer
         </a>
 
         @if (!string.IsNullOrWhiteSpace(name))

--- a/IdentityServer/updateUI.ps1
+++ b/IdentityServer/updateUI.ps1
@@ -1,4 +1,4 @@
-iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/IdentityServer/IdentityServer4.Quickstart.UI/master/getmaster.ps1'))
+iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/DuendeSoftware/IdentityServer.Quickstart.UI/main/getmain.ps1'))
 # SIG # Begin signature block
 # MIIfnQYJKoZIhvcNAQcCoIIfjjCCH4oCAQExDzANBglghkgBZQMEAgEFADB5Bgor
 # BgEEAYI3AgEEoGswaTA0BgorBgEEAYI3AgEeMCYCAwEAAAQQH8w7YFlLCE63JNLG


### PR DESCRIPTION
## Summary
- migrate IdentityServer project from IdentityServer4 to Duende IdentityServer
- update view templates and quickstart script references for Duende IdentityServer

## Testing
- `dotnet build PlanetWar.sln` *(fails: MySql.Data and .NETFramework v4.8 reference errors)*
- `dotnet test PlanetWar.sln` *(fails: build errors prevent test execution)*

------
https://chatgpt.com/codex/tasks/task_e_68978836db488323b45c961eacfceaf0