### PR TITLE
Configure consistent CORS policies across services

### DIFF
--- a/ChatServer/ChatHub.cs
+++ b/ChatServer/ChatHub.cs
@@ -12,7 +12,7 @@ using Microsoft.AspNetCore.Authorization;
 namespace ChatServer
 {
     [Authorize]
-    [EnableCors]
+    [EnableCors("CorsPolicy")]
     public class ChatHub : Hub
     {
         public async Task Send(int chat, string message)

--- a/ChatServer/Startup.cs
+++ b/ChatServer/Startup.cs
@@ -4,6 +4,8 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using System;
+using System.Linq;
 using System.Net.Http;
 using System.Reflection;
 using System.Text;
@@ -12,6 +14,8 @@ namespace ChatServer
 {
     public class Startup
     {
+        private const string CorsPolicyName = "CorsPolicy";
+
         public IConfiguration Config { get; }
 
         public Startup(IConfiguration config)
@@ -23,15 +27,34 @@ namespace ChatServer
         {
             services.AddSignalR();
 
+            var allowedOrigins = Config.GetSection("Cors:AllowedOrigins").Get<string[]>() ?? Array.Empty<string>();
+            allowedOrigins = allowedOrigins
+                .Where(origin => !string.IsNullOrWhiteSpace(origin))
+                .Select(origin => origin.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
             services.AddCors(options =>
             {
-                options.AddPolicy(name: "MyPolicy",
-                    builder =>
+                options.AddPolicy(CorsPolicyName, builder =>
+                {
+                    builder
+                        .AllowAnyHeader()
+                        .AllowAnyMethod();
+
+                    var allowAnyOrigin = allowedOrigins.Length == 0 || allowedOrigins.Any(origin => origin == "*");
+
+                    if (allowAnyOrigin)
                     {
-                        builder.AllowAnyOrigin()
-                                .AllowAnyMethod()
-                                .AllowAnyHeader();
-                    });
+                        builder.SetIsOriginAllowed(_ => true);
+                    }
+                    else
+                    {
+                        builder
+                            .WithOrigins(allowedOrigins)
+                            .AllowCredentials();
+                    }
+                });
             });
 
             // adds DI services to DI and configures bearer as the default scheme
@@ -60,10 +83,9 @@ namespace ChatServer
                 app.UseDeveloperExceptionPage();
             }
 
-            //app.UseCors("MyPolicy");
-            app.UseCors(config => config.AllowAnyHeader().AllowAnyMethod().AllowAnyOrigin());
-
             app.UseRouting();
+
+            app.UseCors(CorsPolicyName);
 
             app.UseEndpoints(endpoints =>
             {

--- a/ChatServer/appsettings.json
+++ b/ChatServer/appsettings.json
@@ -6,5 +6,10 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Cors": {
+    "AllowedOrigins": [
+      "http://localhost:3000"
+    ]
+  }
 }

--- a/GameServer/Startup.cs
+++ b/GameServer/Startup.cs
@@ -21,6 +21,8 @@ namespace CommonLibrary
 {
     public class Startup
     {
+        private const string CorsPolicyName = "CorsPolicy";
+
         public IConfiguration Configuration { get; }
 
         public Startup(IConfiguration configuration)
@@ -30,7 +32,35 @@ namespace CommonLibrary
 
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddCors();
+            var allowedOrigins = Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>() ?? Array.Empty<string>();
+            allowedOrigins = allowedOrigins
+                .Where(origin => !string.IsNullOrWhiteSpace(origin))
+                .Select(origin => origin.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            services.AddCors(options =>
+            {
+                options.AddPolicy(CorsPolicyName, builder =>
+                {
+                    builder
+                        .AllowAnyHeader()
+                        .AllowAnyMethod();
+
+                    var allowAnyOrigin = allowedOrigins.Length == 0 || allowedOrigins.Any(origin => origin == "*");
+
+                    if (allowAnyOrigin)
+                    {
+                        builder.SetIsOriginAllowed(_ => true);
+                    }
+                    else
+                    {
+                        builder
+                            .WithOrigins(allowedOrigins)
+                            .AllowCredentials();
+                    }
+                });
+            });
 
             // adds DI services to DI and configures bearer as the default scheme
             services.AddAuthentication("Bearer")
@@ -63,13 +93,7 @@ namespace CommonLibrary
         {
             IdentityModelEventSource.ShowPII = true;
 
-            app.UseCors(builder =>
-                 builder
-                   .WithOrigins("http://localhost:3000")
-                   .AllowAnyHeader()
-                   .AllowAnyMethod()
-                   .AllowCredentials()
-               );
+            app.UseCors(CorsPolicyName);
             // adds authentication middleware to the pipeline so authentication will be performed on every request
             app.UseAuthentication();
             app.UseMvc();

--- a/GameServer/appsettings.json
+++ b/GameServer/appsettings.json
@@ -1,5 +1,10 @@
 {
   "ConnectionStrings": {
     "DefaultConnection": "Server=(localdb)\\MSSQLLocalDB;Database=_CHANGE_ME;Trusted_Connection=True;MultipleActiveResultSets=true"
+  },
+  "Cors": {
+    "AllowedOrigins": [
+      "http://localhost:3000"
+    ]
   }
 }

--- a/IdentityServer/Startup.cs
+++ b/IdentityServer/Startup.cs
@@ -12,11 +12,15 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.IdentityModel.Tokens;
+using System;
+using System.Linq;
 
 namespace IdentityServer
 {
     public class Startup
     {
+        private const string CorsPolicyName = "CorsPolicy";
+
         public IConfiguration Configuration { get; }
 
         public Startup(IConfiguration configuration)
@@ -27,6 +31,35 @@ namespace IdentityServer
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddControllersWithViews();
+
+            var allowedOrigins = Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>() ?? Array.Empty<string>();
+            allowedOrigins = allowedOrigins
+                .Where(origin => !string.IsNullOrWhiteSpace(origin))
+                .Select(origin => origin.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            services.AddCors(options =>
+            {
+                options.AddPolicy(CorsPolicyName, builder =>
+                {
+                    builder
+                        .AllowAnyHeader()
+                        .AllowAnyMethod();
+
+                    var allowAnyOrigin = allowedOrigins.Length == 0 || allowedOrigins.Any(origin => origin == "*");
+
+                    if (allowAnyOrigin)
+                    {
+                        builder.SetIsOriginAllowed(_ => true);
+                    }
+                    else
+                    {
+                        builder.WithOrigins(allowedOrigins);
+                        builder.AllowCredentials();
+                    }
+                });
+            });
             
             services.AddSingleton(new DatabaseService(Configuration.GetValue<string>("login"), Configuration.GetValue<string>("password")));
 
@@ -52,6 +85,8 @@ namespace IdentityServer
 
             app.UseStaticFiles();
             app.UseRouting();
+
+            app.UseCors(CorsPolicyName);
 
             app.UseIdentityServer();
             app.UseAuthentication();

--- a/IdentityServer/appsettings.json
+++ b/IdentityServer/appsettings.json
@@ -1,4 +1,9 @@
 ﻿{
+  "Cors": {
+    "AllowedOrigins": [
+      "http://localhost:3000"
+    ]
+  },
   "IdentityResources": [
     {
       "Name": "openid",

--- a/LaunchServer/Startup.cs
+++ b/LaunchServer/Startup.cs
@@ -1,5 +1,7 @@
 ﻿using System.Net.Http;
 using System.Reflection;
+using System;
+using System.Linq;
 using LaunchServer.Controllers;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -14,6 +16,8 @@ namespace LaunchServer
 {
     public class Startup
     {
+        private const string CorsPolicyName = "CorsPolicy";
+
         public IConfiguration Configuration { get; }
 
         public Startup(IConfiguration configuration)
@@ -23,7 +27,35 @@ namespace LaunchServer
 
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddCors();
+            var allowedOrigins = Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>() ?? Array.Empty<string>();
+            allowedOrigins = allowedOrigins
+                .Where(origin => !string.IsNullOrWhiteSpace(origin))
+                .Select(origin => origin.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            services.AddCors(options =>
+            {
+                options.AddPolicy(CorsPolicyName, builder =>
+                {
+                    builder
+                        .AllowAnyHeader()
+                        .AllowAnyMethod();
+
+                    var allowAnyOrigin = allowedOrigins.Length == 0 || allowedOrigins.Any(origin => origin == "*");
+
+                    if (allowAnyOrigin)
+                    {
+                        builder.SetIsOriginAllowed(_ => true);
+                    }
+                    else
+                    {
+                        builder
+                            .WithOrigins(allowedOrigins)
+                            .AllowCredentials();
+                    }
+                });
+            });
 
             // adds DI services to DI and configures bearer as the default scheme
             services.AddAuthentication("Bearer")
@@ -52,13 +84,7 @@ namespace LaunchServer
         {
             IdentityModelEventSource.ShowPII = true;
 
-            app.UseCors(builder =>
-                 builder
-                   .WithOrigins("http://localhost:3000")
-                   .AllowAnyHeader()
-                   .AllowAnyMethod()
-                   .AllowCredentials()
-               );
+            app.UseCors(CorsPolicyName);
             // adds authentication middleware to the pipeline so authentication will be performed on every request
             app.UseAuthentication();
             app.UseMvc();

--- a/LaunchServer/appsettings.json
+++ b/LaunchServer/appsettings.json
@@ -1,5 +1,10 @@
 {
   "ConnectionStrings": {
     "DefaultConnection": "Server=(localdb)\\MSSQLLocalDB;Database=_CHANGE_ME;Trusted_Connection=True;MultipleActiveResultSets=true"
+  },
+  "Cors": {
+    "AllowedOrigins": [
+      "http://localhost:3000"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- introduce a named CORS policy in each service that reads allowed origins from configuration
- add `Cors:AllowedOrigins` settings to every service so the policy can be managed without code changes
- wire the chat hub and IdentityServer pipeline to use the shared policy for cross-origin requests

## Testing
- not run (dotnet CLI unavailable in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d6292613c08323a514d05dbfa14a3e